### PR TITLE
Make the module work with drupal compatibility disabled

### DIFF
--- a/geophp.info
+++ b/geophp.info
@@ -1,5 +1,4 @@
 name = geoPHP
 description = Wraps the geoPHP library: advanced geometry operations in PHP
-core = 7.x
 backdrop = 1.x
 type = module

--- a/geophp.module
+++ b/geophp.module
@@ -20,7 +20,7 @@ function geophp_load() {
     
     if (module_exists('libraries')) {
       $path = libraries_get_path('geoPHP');
-      $file = DRUPAL_ROOT . '/' . $path . '/geoPHP.inc';
+      $file = BACKDROP_ROOT . '/' . $path . '/geoPHP.inc';
       if (file_exists($file) && $static_cache !== TRUE) {
         include_once($file);
         $already_found = TRUE;


### PR DESCRIPTION
This pull request replaces the world DRUPAL with BACKDROP to make the module fully compatible with Backdrop (drupal word in functions, variables and constants only work with drupal compatibility setting enabled). It also replaces core=7.x line from geophp.info.